### PR TITLE
added pre-scrollable tag to event-list/detail divs

### DIFF
--- a/src/app/event-view/event-view.component.html
+++ b/src/app/event-view/event-view.component.html
@@ -1,12 +1,21 @@
+<style>
+    .pre-scrollable{
+        max-height: 70vh;
+    }
+</style>
 <div class="container">
     <h1>Your Events</h1>
     <div class="row">
-            <event-list class="col-xs-4"
+        <div class="col-xs-4 pre-scrollable">
+            <event-list
                 [events]="events"
                 (onSelected)="onSelected($event)">
             </event-list>
-        <event-detail class="col-xs-8"
-            [event]="selectedEvent">
-        </event-detail>
+        </div>
+        <div class="col-xs-8 pre-scrollable">
+            <event-detail
+                [event]="selectedEvent">
+            </event-detail>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
- Event list and detail view now scroll independently

- Lists extend to 70% of the monitor's height